### PR TITLE
fixing sources for accounting_book_id

### DIFF
--- a/models/netsuite2/intermediate/base/int_netsuite2__transaction_lines.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__transaction_lines.sql
@@ -17,6 +17,7 @@ joined as (
     select 
         transaction_lines.*,
         transaction_accounting_lines.account_id,
+        transaction_accounting_lines.accounting_book_id,
         transaction_accounting_lines.amount,
         transaction_accounting_lines.credit_amount,
         transaction_accounting_lines.debit_amount,

--- a/models/netsuite2/intermediate/int_netsuite2__acctxperiod_exchange_rate_map.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__acctxperiod_exchange_rate_map.sql
@@ -25,7 +25,6 @@ consolidated_exchange_rates as (
 period_exchange_rate_map as ( -- exchange rates used, by accounting period, to convert to parent subsidiary
   select
     consolidated_exchange_rates.accounting_period_id,
-    consolidated_exchange_rates.accounting_book_id,
     consolidated_exchange_rates.average_rate,
     consolidated_exchange_rates.current_rate,
     consolidated_exchange_rates.historical_rate,
@@ -42,7 +41,6 @@ period_exchange_rate_map as ( -- exchange rates used, by accounting period, to c
 accountxperiod_exchange_rate_map as ( -- account table with exchange rate details by accounting period
   select
     period_exchange_rate_map.accounting_period_id,
-    period_exchange_rate_map.accounting_book_id,
     period_exchange_rate_map.from_subsidiary_id,
     period_exchange_rate_map.to_subsidiary_id,
     accounts.account_id,

--- a/models/netsuite2/intermediate/int_netsuite2__tran_lines_w_accounting_period.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__tran_lines_w_accounting_period.sql
@@ -16,6 +16,7 @@ transaction_lines_w_accounting_period as ( -- transaction line totals, by accoun
     transaction_lines.transaction_line_id,
     transaction_lines.subsidiary_id,
     transaction_lines.account_id,
+    transaction_lines.accounting_book_id,
     transactions.accounting_period_id as transaction_accounting_period_id,
     coalesce(transaction_lines.amount, 0) as unconverted_amount
   from transaction_lines

--- a/models/netsuite2/intermediate/int_netsuite2__tran_with_converted_amounts.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__tran_with_converted_amounts.sql
@@ -29,7 +29,6 @@ transactions_in_every_calculation_period_w_exchange_rates as (
     
     {% if var('netsuite2__using_exchange_rate', true) %}
     , exchange_reporting_period.exchange_rate as exchange_rate_reporting_period
-    , exchange_transaction_period.accounting_book_id as accounting_book_id
     , exchange_transaction_period.exchange_rate as exchange_rate_transaction_period
     {% endif %}
 


### PR DESCRIPTION
Merge `hotfix_accounting_book_id` into `main`. This corrects an issue where `accounting_book_id` value in modeled tables doesn't match the source.