### PR TITLE
Add base book transactions to adjustment only book

### DIFF
--- a/models/netsuite2/intermediate/base/int_netsuite2__transaction_lines.sql
+++ b/models/netsuite2/intermediate/base/int_netsuite2__transaction_lines.sql
@@ -12,6 +12,12 @@ transaction_accounting_lines as (
     from {{ var('netsuite2_transaction_accounting_lines') }}
 ),
 
+accounting_books as (
+
+    select *
+    from {{ var('netsuite2_accounting_books') }}
+),
+
 joined as (
 
     select 
@@ -29,6 +35,30 @@ joined as (
     left join transaction_accounting_lines
         on transaction_lines.transaction_line_id = transaction_accounting_lines.transaction_line_id
         and transaction_lines.transaction_id = transaction_accounting_lines.transaction_id
+
+  {% if var('netsuite2__multibook_accounting_enabled', true) %}
+    union all
+
+    select
+        transaction_lines.*,
+        transaction_accounting_lines.account_id,
+        accounting_books.accounting_book_id,
+        transaction_accounting_lines.amount,
+        transaction_accounting_lines.credit_amount,
+        transaction_accounting_lines.debit_amount,
+        transaction_accounting_lines.paid_amount,
+        transaction_accounting_lines.unpaid_amount,
+        transaction_accounting_lines.is_posting
+
+    from transaction_lines
+    left join transaction_accounting_lines
+        on transaction_lines.transaction_line_id = transaction_accounting_lines.transaction_line_id
+        and transaction_lines.transaction_id = transaction_accounting_lines.transaction_id
+    left join accounting_books
+        on accounting_books.base_book_id = transaction_accounting_lines.accounting_book_id
+    where accounting_books.base_book_id is not null
+  {% endif %}
+
 )
 
 select *

--- a/models/netsuite2/intermediate/int_netsuite2__acctxperiod_exchange_rate_map.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__acctxperiod_exchange_rate_map.sql
@@ -25,6 +25,7 @@ consolidated_exchange_rates as (
 period_exchange_rate_map as ( -- exchange rates used, by accounting period, to convert to parent subsidiary
   select
     consolidated_exchange_rates.accounting_period_id,
+    consolidated_exchange_rates.accounting_book_id,
     consolidated_exchange_rates.average_rate,
     consolidated_exchange_rates.current_rate,
     consolidated_exchange_rates.historical_rate,
@@ -33,14 +34,12 @@ period_exchange_rate_map as ( -- exchange rates used, by accounting period, to c
   from consolidated_exchange_rates
 
   where consolidated_exchange_rates.to_subsidiary_id in (select subsidiary_id from subsidiaries where parent_id is null)  -- constraint - only the primary subsidiary has no parent
-  {% if var('netsuite2__multibook_accounting_enabled', true) %}
-    and consolidated_exchange_rates.accounting_book_id in (select accounting_book_id from accounting_books where is_primary)
-  {% endif %}
 ), 
 
 accountxperiod_exchange_rate_map as ( -- account table with exchange rate details by accounting period
   select
     period_exchange_rate_map.accounting_period_id,
+    period_exchange_rate_map.accounting_book_id,
     period_exchange_rate_map.from_subsidiary_id,
     period_exchange_rate_map.to_subsidiary_id,
     accounts.account_id,

--- a/models/netsuite2/intermediate/int_netsuite2__tran_with_converted_amounts.sql
+++ b/models/netsuite2/intermediate/int_netsuite2__tran_with_converted_amounts.sql
@@ -42,11 +42,13 @@ transactions_in_every_calculation_period_w_exchange_rates as (
     on exchange_reporting_period.accounting_period_id = transaction_and_reporting_periods.reporting_accounting_period_id
       and exchange_reporting_period.account_id = transaction_lines_w_accounting_period.account_id
       and exchange_reporting_period.from_subsidiary_id = transaction_lines_w_accounting_period.subsidiary_id
+      and exchange_reporting_period.accounting_book_id = transaction_lines_w_accounting_period.accounting_book_id
       
   left join accountxperiod_exchange_rate_map as exchange_transaction_period
     on exchange_transaction_period.accounting_period_id = transaction_and_reporting_periods.accounting_period_id
       and exchange_transaction_period.account_id = transaction_lines_w_accounting_period.account_id
       and exchange_transaction_period.from_subsidiary_id = transaction_lines_w_accounting_period.subsidiary_id
+      and exchange_transaction_period.accounting_book_id = transaction_lines_w_accounting_period.accounting_book_id
   {% endif %}
 ), 
 

--- a/models/netsuite2/netsuite2__balance_sheet.sql
+++ b/models/netsuite2/netsuite2__balance_sheet.sql
@@ -110,6 +110,7 @@ balance_sheet as (
   left join transaction_details
     on transaction_details.transaction_id = transactions_with_converted_amounts.transaction_id
       and transaction_details.transaction_line_id = transactions_with_converted_amounts.transaction_line_id
+      and transaction_details.accounting_book_id = transactions_with_converted_amounts.accounting_book_id
   {% endif %}
 
 
@@ -170,6 +171,7 @@ balance_sheet as (
   left join transaction_details
     on transaction_details.transaction_id = transactions_with_converted_amounts.transaction_id
       and transaction_details.transaction_line_id = transactions_with_converted_amounts.transaction_line_id
+      and transaction_details.accounting_book_id = transactions_with_converted_amounts.accounting_book_id
   {% endif %}
 
   left join accounts

--- a/models/netsuite2/netsuite2__income_statement.sql
+++ b/models/netsuite2/netsuite2__income_statement.sql
@@ -104,6 +104,7 @@ income_statement as (
     join transaction_lines as transaction_lines
         on transaction_lines.transaction_line_id = transactions_with_converted_amounts.transaction_line_id
             and transaction_lines.transaction_id = transactions_with_converted_amounts.transaction_id
+            and transaction_lines.accounting_book_id = transactions_with_converted_amounts.accounting_book_id
 
     left join departments 
         on departments.department_id = transaction_lines.department_id
@@ -128,6 +129,7 @@ income_statement as (
     join transaction_details
         on transaction_details.transaction_id = transactions_with_converted_amounts.transaction_id
         and transaction_details.transaction_line_id = transactions_with_converted_amounts.transaction_line_id
+        and transaction_details.accounting_book_id = transactions_with_converted_amounts.accounting_book_id
     {% endif %}
 
     where reporting_accounting_periods.fiscal_calendar_id  = (select fiscal_calendar_id from subsidiaries where parent_id is null)

--- a/models/netsuite2/netsuite2__transaction_details.sql
+++ b/models/netsuite2/netsuite2__transaction_details.sql
@@ -160,6 +160,7 @@ transaction_details as (
     on transactions_with_converted_amounts.transaction_line_id = transaction_lines.transaction_line_id
       and transactions_with_converted_amounts.transaction_id = transaction_lines.transaction_id
       and transactions_with_converted_amounts.transaction_accounting_period_id = transactions_with_converted_amounts.reporting_accounting_period_id
+      and transactions_with_converted_amounts.accounting_book_id = transaction_lines.accounting_book_id
 
   left join accounts 
     on accounts.account_id = transaction_lines.account_id


### PR DESCRIPTION
Adds transaction lines from base book onto related adjustment only book. 'converted_amount' translated at the book-specific consolidated exchange rate. Fixes downstream joins to include accounting_book_id.