### PR TITLE
Fix RE and CTA types in balance sheet

### DIFF
--- a/models/netsuite2/netsuite2__balance_sheet.sql
+++ b/models/netsuite2/netsuite2__balance_sheet.sql
@@ -51,6 +51,8 @@ balance_sheet as (
             and {{ dbt.date_trunc('year', 'reporting_accounting_periods.starting_at') }} = {{ dbt.date_trunc('year', 'transaction_accounting_periods.starting_at') }} 
             and reporting_accounting_periods.fiscal_calendar_id = transaction_accounting_periods.fiscal_calendar_id) then 'Net Income'
       when not accounts.is_balancesheet then 'Retained Earnings'
+      when lower(accounts.special_account_type_id) = 'retearnings' then 'Retained Earnings'
+      when lower(accounts.special_account_type_id) IN ('cta-e', 'cumultransadj') then 'Cumulative Translation Adjustment'
       else accounts.type_name
         end as account_type_name,
     case
@@ -58,6 +60,8 @@ balance_sheet as (
             and {{ dbt.date_trunc('year', 'reporting_accounting_periods.starting_at') }} = {{ dbt.date_trunc('year', 'transaction_accounting_periods.starting_at') }} 
             and reporting_accounting_periods.fiscal_calendar_id = transaction_accounting_periods.fiscal_calendar_id) then 'net_income'
       when not accounts.is_balancesheet then 'retained_earnings'
+      when lower(accounts.special_account_type_id) = 'retearnings' then 'retained_earnings'
+      when lower(accounts.special_account_type_id) IN ('cta-e', 'cumultransadj') then 'cumulative_translation_adjustment'
       else accounts.account_type_id
         end as account_type_id,
     case
@@ -95,6 +99,8 @@ balance_sheet as (
       when lower(accounts.account_type_id) = 'othcurrliab' then 10
       when lower(accounts.account_type_id) = 'longtermliab' then 11
       when lower(accounts.account_type_id) = 'deferrevenue' then 12
+      when lower(accounts.special_account_type_id) = 'retearnings' then 14
+      when lower(accounts.special_account_type_id) IN ('cta-e', 'cumultransadj') then 16
       when lower(accounts.account_type_id) = 'equity' then 13
       when (not accounts.is_balancesheet 
             and {{ dbt.date_trunc('year', 'reporting_accounting_periods.starting_at') }} = {{ dbt.date_trunc('year', 'transaction_accounting_periods.starting_at') }} 


### PR DESCRIPTION
It is possible to record entries directly to the system generated retained earnings and CTA accounts in NetSuite. The balance sheet model is presenting entries to those accounts as `Equity`. Model calculated amounts are presented in `Retained Earnings` and `Cumulative Translation Adjustment`.

This patch fixes the categorization so it matches the NetSuite Balance Sheet report.